### PR TITLE
Check for error stack overflow when providing position

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@
 
 module.exports = function getCallerFile(_position) {
 
-  const stackTraceLimit = Error.stackTraceLimit-1;
-  const errorMessage=`ErrorStackTraceLimit overflow. Can pass less then ${stackTraceLimit} or increase property Error.stackTraceLimit`;
+  var stackTraceLimit = Error.stackTraceLimit-1;
+  var errorMessage='ErrorStackTraceLimit overflow. Can pass less then ' + stackTraceLimit + ' or increase property Error.stackTraceLimit';
 
   if(_position > stackTraceLimit){
     throw errorMessage;
   }
-  
+
   var oldPrepareStackTrace = Error.prepareStackTrace;
   Error.prepareStackTrace = function(err, stack) { return stack; };
   var stack = new Error().stack;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,14 @@
 // Inspired by http://stackoverflow.com/questions/13227489
 
 module.exports = function getCallerFile(_position) {
+
+  const stackTraceLimit = Error.stackTraceLimit-1;
+  const errorMessage=`ErrorStackTraceLimit overflow. Can pass less then ${stackTraceLimit} or increase property Error.stackTraceLimit`;
+
+  if(_position > stackTraceLimit){
+    throw errorMessage;
+  }
+  
   var oldPrepareStackTrace = Error.prepareStackTrace;
   Error.prepareStackTrace = function(err, stack) { return stack; };
   var stack = new Error().stack;

--- a/index.js
+++ b/index.js
@@ -6,12 +6,10 @@
 // Inspired by http://stackoverflow.com/questions/13227489
 
 module.exports = function getCallerFile(_position) {
+  var position = _position ? _position : 2;
 
-  var stackTraceLimit = Error.stackTraceLimit-1;
-  var errorMessage='ErrorStackTraceLimit overflow. Can pass less then ' + stackTraceLimit + ' or increase property Error.stackTraceLimit';
-
-  if(_position > stackTraceLimit){
-    throw errorMessage;
+  if (position >= Error.stackTraceLimit) {
+    throw new TypeError('getCallerFile(position) requires position be less then Error.stackTraceLimit but position was: `' + position + '` and Error.stackTraceLimit was: `' + Error.stackTraceLimit + '`');
   }
 
   var oldPrepareStackTrace = Error.prepareStackTrace;
@@ -19,7 +17,6 @@ module.exports = function getCallerFile(_position) {
   var stack = new Error().stack;
   Error.prepareStackTrace = oldPrepareStackTrace;
 
-  var position = _position ? _position : 2;
 
   // stack[0] holds this file
   // stack[1] holds where this function was called

--- a/test.js
+++ b/test.js
@@ -18,4 +18,13 @@ describe('getCallerFile', function() {
   it('gets another file, as it is the caller', function() {
     expect(ensurePosix(bar())).to.eql(ensurePosix(__dirname + '/fixtures/bar.js'));
   });
+
+  xit('throws error if error stackTraceLimit overflow', () => {
+    expect(getCallerFile(12)).to.throw(Error);
+  });
+
+  xit('throws no errors if incrementing error stackTraceLimit ', () => {
+    Error.stackTraceLimit = 14;
+    expect(getCallerFile(12)).to.not.throw(Error);
+  });
 });

--- a/test.js
+++ b/test.js
@@ -19,11 +19,11 @@ describe('getCallerFile', function() {
     expect(ensurePosix(bar())).to.eql(ensurePosix(__dirname + '/fixtures/bar.js'));
   });
 
-  xit('throws error if error stackTraceLimit overflow', () => {
+  xit('throws error if error stackTraceLimit overflow', function(){
     expect(getCallerFile(12)).to.throw(Error);
   });
 
-  xit('throws no errors if incrementing error stackTraceLimit ', () => {
+  xit('throws no errors if incrementing error stackTraceLimit ', function(){
     Error.stackTraceLimit = 14;
     expect(getCallerFile(12)).to.not.throw(Error);
   });

--- a/test.js
+++ b/test.js
@@ -7,6 +7,10 @@ var bar = require('./fixtures/bar');
 var ensurePosix = require('ensure-posix-path');
 
 describe('getCallerFile', function() {
+  var originalStackTraceLimit = Error.stackTraceLimit;
+
+  afterEach(() => Error.stackTraceLimit = originalStackTraceLimit);
+
   it('gets current caller file', function() {
     expect(ensurePosix(getCallerFile())).to.eql(ensurePosix(__dirname + '/node_modules/mocha/lib/runnable.js'));
   });
@@ -19,12 +23,14 @@ describe('getCallerFile', function() {
     expect(ensurePosix(bar())).to.eql(ensurePosix(__dirname + '/fixtures/bar.js'));
   });
 
-  xit('throws error if error stackTraceLimit overflow', function(){
-    expect(getCallerFile(12)).to.throw(Error);
+
+  it('throws error if error stackTraceLimit overflow', function() {
+    Error.stackTraceLimit = 5;
+    expect(() => getCallerFile(Error.stackTraceLimit + 1)).to.throw(TypeError);
   });
 
-  xit('throws no errors if incrementing error stackTraceLimit ', function(){
-    Error.stackTraceLimit = 14;
-    expect(getCallerFile(12)).to.not.throw(Error);
+  it('throws no errors if incrementing error stackTraceLimit ', function() {
+    Error.stackTraceLimit = 5;
+    expect(() => getCallerFile(Error.stackTraceLimit - 1)).to.not.throw(TypeError);
   });
 });


### PR DESCRIPTION
Just a check so that the user is not giving a position more than the configured StackTrace limit size.
There is a problem with tests so currently these two tests are disabled.
If anyone can help out it would be great, Mocha outputing 'expecting timers.js to be a function' ??